### PR TITLE
moved handling extension code reserved bytes to a warning

### DIFF
--- a/mpkedit.js
+++ b/mpkedit.js
@@ -166,9 +166,9 @@ var MPKEdit = (function() {
 				if(data[i + 12] !== 0) {
 					noteName += ".";
 					noteName += this.n64code[data[i + 12]] || "";
-					noteName += this.n64code[data[i + 13]] || "";
-					noteName += this.n64code[data[i + 14]] || "";
-					noteName += this.n64code[data[i + 15]] || "";
+				}
+				if (data[i + 13] | data[i + 14] | data[i + 15]) {
+					console.warn("Reserved bits of extension code should be zero.");
 				}
 	
 				NoteTable[(i - 0x300) / 32] = {


### PR DESCRIPTION
I was thinking--since it's explicitly documented that the last 3 bytes of the 4-byte "note extension" are reserved (and ideally should always be 0x00), wouldn't it make more sense to only care about reading the first byte (which isn't reserved)?

The last 3 bytes can still be checked for mempak _"legitimacy"_ (sort of), as done in this commit, though I think that if they're documented to be 0 and reserved, it probably wouldn't hurt to use them as a method of detecting an unusual mempak with a little warning on the console.

Either way, I don't think they should be treated as part of the official note name.